### PR TITLE
Fixes M42 Pxx led control on Melzi hardware

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -1040,7 +1040,7 @@
 #endif
 
 #ifdef MELZI
- //#define LED_PIN            27 /* On some broken versions of the Sanguino libraries the pin definitions are wrong, which then needs LED_PIN as pin 28. But you better upgrade your Sanguino libraries! See #368. */
+ #define LED_PIN            27 /* On some broken versions of the Sanguino libraries the pin definitions are wrong, which then needs LED_PIN as pin 28. But you better upgrade your Sanguino libraries! See #368. */
  #define FAN_PIN            4 // Works for Panelolu2 too
 #endif
 


### PR DESCRIPTION
Fixes M42 Pxx on Melzi hardware.
It is a minor "fix", and it won't affect many users, but it also keeps the code closer to the original Marlin.
